### PR TITLE
Add missing vertex shader

### DIFF
--- a/assets/shader/util.vert
+++ b/assets/shader/util.vert
@@ -208,6 +208,9 @@ vec4 _color(vec4 color, Nothing intensity, Nothing color_map, Nothing color_norm
 vec4 _color(samplerBuffer color, Nothing intensity, Nothing color_norm, int index){
     return texelFetch(color, index);
 }
+vec4 _color(samplerBuffer color, Nothing intensity, Nothing color_map, Nothing color_norm, int index){
+    return texelFetch(color, index);
+}
 vec4 _color(Nothing color, samplerBuffer intensity, sampler1D color_map, vec2 color_norm, int index){
     return color_lookup(texelFetch(intensity, index).x, color_map, color_norm);
 }


### PR DESCRIPTION
This gets the "particles/particles.jl" demo working for me.

Does `particles/cubicles.jl` work for you? I get
```jl
ERROR: LoadError: MethodError: `convert` has no method matching convert(::Type{GLAbstraction.PerspectiveCamera{T}}, ::Reactive.Signal{FixedSizeArrays.Vec{3,Float32}}, ::Reactive.Signal{FixedSizeArrays.Vec{3,Float32}}, ::Reactive.Signal{FixedSizeArrays.Vec{3,Float32}}, ::Reactive.Signal{FixedSizeArrays.Vec{3,Float32}}, ::Reactive.Signal{FixedSizeArrays.Vec{3,Float32}}, ::Reactive.Signal{GeometryTypes.SimpleRectangle{Int64}}, ::Reactive.Signal{Float32}, ::Reactive.Signal{Float32}, ::Reactive.Signal{Float32}, ::Reactive.Signal{GLAbstraction.Projection})
This may have arisen from a call to the constructor GLAbstraction.PerspectiveCamera{T}(...),
since type constructors fall back to convert methods.
Closest candidates are:
  GLAbstraction.PerspectiveCamera{T<:Real}(::Reactive.Signal{GeometryTypes.SimpleRectangle{Int64}}, ::Union{FixedSizeArrays.Vec{3,T<:Real},Reactive.Signal{FixedSizeArrays.Vec{3,T<:Real}}}, ::Union{FixedSizeArrays.Vec{3,T<:Real},Reactive.Signal{FixedSizeArrays.Vec{3,T<:Real}}}, ::Reactive.Signal{FixedSizeArrays.Vec{3,T<:Real}}, ::Reactive.Signal{FixedSizeArrays.Vec{3,T<:Real}}, ::Reactive.Signal{T<:Real}, ::Reactive.Signal{T<:Real}, ::Reactive.Signal{T<:Real}, ::Any, ::Any)
  GLAbstraction.PerspectiveCamera{T<:Real}(::Reactive.Signal{GeometryTypes.SimpleRectangle{Int64}}, ::Union{FixedSizeArrays.Vec{3,T<:Real},Reactive.Signal{FixedSizeArrays.Vec{3,T<:Real}}}, ::Union{FixedSizeArrays.Vec{3,T<:Real},Reactive.Signal{FixedSizeArrays.Vec{3,T<:Real}}}, ::Reactive.Signal{FixedSizeArrays.Vec{3,T<:Real}}, ::Reactive.Signal{FixedSizeArrays.Vec{3,T<:Real}}, ::Reactive.Signal{T<:Real}, ::Reactive.Signal{T<:Real}, ::Reactive.Signal{T<:Real}, ::Any, ::Any, ::Any)
  GLAbstraction.PerspectiveCamera{T<:Real}(::Reactive.Signal{GeometryTypes.SimpleRectangle{Int64}}, ::Union{FixedSizeArrays.Vec{3,T<:Real},Reactive.Signal{FixedSizeArrays.Vec{3,T<:Real}}}, ::Union{FixedSizeArrays.Vec{3,T<:Real},Reactive.Signal{FixedSizeArrays.Vec{3,T<:Real}}}, ::Reactive.Signal{FixedSizeArrays.Vec{3,T<:Real}}, ::Reactive.Signal{FixedSizeArrays.Vec{3,T<:Real}}, ::Reactive.Signal{T<:Real}, ::Reactive.Signal{T<:Real}, ::Reactive.Signal{T<:Real}, ::Any, ::Any, ::Any, ::Any)
  ...
 in call at essentials.jl:57
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
while loading /home/temp/.julia/v0.4/GLVisualize/examples/particles/cubicles.jl, in expression starting on line 40
```
(The red coloration I see when I run this locally suggests it's a `Reactive.Signal` type problem.)

Relatedly, I'm just teaching myself OpenGL. Your recent work on the examples is enormously helpful. I'm also going through http://www.opengl-tutorial.org/beginners-tutorials and trying to replicate them in GLVisualize. On the tutorial 2, here are my notes-in-progress, which highlight some unexpected behavior:

## Grayscale triangle

	using GLVisualize, GeometryTypes
	
    # Construct a triangle in terms of vertices & faces
    ## Provide the (x,y,z) location of each vertex
	v = Point3f0[(-1, -1, 0), (1, -1, 0), (0, 1, 0)]

Now we specify how these vertices are connected together to form the
"faces" of a faceted object. This is provided as a list of faces, each
face specified as a list of vertex indexes that comprise it. The
`Face{N,T,O}` type specifies a face with `N` vertices, with index type
`T` (you should choose `UInt32`), and index-offset `O`. If you're
specifying faces in terms of julia's 1-based indexing, you should set
`O=-1`. (If you instead number the vertices starting with 0, set
`O=0`.)

    ## Provide the list of faces, specified as a 1-based vertex index
    ## This is a simple case: our triangle has only one face
    f = Face{3,UInt32,-1}[(1,2,3)]

	msh = GLNormalMesh(vertices=v, faces=f)

	window = glscreen()

	vis = visualize(msh)
	view(vis, window)

	renderloop(window)

You can rotate the triangle in 3d space by click-drag with the left
mouse button, and translate the triangle by click-drag with the right
mouse button.

## Colorful triangle

?: how to use the `color` field of `HomogeneousMesh`? I tried this:

    msh = GLNormalMesh(vertices=v, faces=f, color=RGBA{U8}(1,0,0,1))
	msh2 = merge(msh)  # sets attributes and attribute_id
	vis = visualize(msh2)
	
but it gave a `MethodError` (for `_default`). I also tried this:

	msh = GLNormalMesh(vertices=v, faces=f)
	vis = visualize(msh, color=fill(RGBA{Float32}(1,0,0,1), 3))

but the triangle wasn't visible.

