### PR TITLE
Support AxisArrays and suppress warnings for the old Images syntax

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -25,3 +25,5 @@ FreeType
 Iterators
 Packing
 UnicodeFun
+
+Compat 0.18

--- a/src/GLVisualize.jl
+++ b/src/GLVisualize.jl
@@ -18,12 +18,18 @@ using SignedDistanceFields
 using FreeType
 using Iterators
 using Base.Markdown
+using Compat   # in preparation for Julia 0.6
 
 import ColorVectorSpace
 import GLAbstraction: N0f8
 export N0f8 # reexport for examples/tests
 
 import Images
+# Are we using the new Images?
+if isdefined(Images, :ImageAxes)
+    using AxisArrays, ImageAxes
+    @compat const HasAxesArray{T,N} = Union{AxisArray{T,N}, Images.ImageMetadata.ImageMetaAxis{T,N}}
+end
 
 import Base: merge, convert, show
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -232,6 +232,7 @@ immutable Intensity{N, T} <: FixedVector{N, T}
     _::NTuple{N, T}
 end
 typealias GLIntensity Intensity{1, Float32}
+(::Type{Intensity{1,T}}){T,Tc}(x::Color{Tc,1}) = Intensity{1,T}(gray(x))
 export Intensity,GLIntensity
 
 NOT(x) = !x

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,10 +2,14 @@
 Determines if of Image Type
 """
 function isa_image{T<:Matrix}(x::Type{T})
-    eltype(T) <: Union{Colorant, AbstractFloat}
+    eltype(T) <: Union{Colorant, Colors.Fractional}
 end
 isa_image(x::Matrix) = isa_image(typeof(x))
-isa_image(x::Images.Image) = true
+if !isdefined(Images, :ImageAxes)
+    include_string("""
+    isa_image(x::Images.Image) = true
+    """)
+end
 isa_image(x) = false
 
 # Splits a dictionary in two dicts, via a condition

--- a/src/visualize/particles.jl
+++ b/src/visualize/particles.jl
@@ -322,13 +322,23 @@ primitive_distancefield(::Char) = get_texture_atlas().images
 
 
 
-"""
-Particles with an image as primitive
-"""
-function _default{Pr <: Images.Image, P <: Point}(
+if isdefined(Images, :ImageAxes)
+    """
+    Particles with an image as primitive
+    """
+    function _default{Pr <: HasAxesArray, P <: Point}(
         p::Tuple{TOrSignal{Pr}, VecTypes{P}}, s::Style, data::Dict
     )
-    _default((const_lift(img -> img.data, p[1]), p[2]), s, data)
+        _default((const_lift(img -> gl_convert(img), p[1]), p[2]), s, data)
+    end
+else
+    include_string("""
+    function _default{Pr <: Images.Image, P <: Point}(
+            p::Tuple{TOrSignal{Pr}, VecTypes{P}}, s::Style, data::Dict
+        )
+        _default((const_lift(img -> img.data, p[1]), p[2]), s, data)
+    end
+    """)
 end
 function _default{C <: Colorant, P <: Point}(
         p::Tuple{TOrSignal{Matrix{C}}, VecTypes{P}}, s::Style, data::Dict

--- a/test/micro.jl
+++ b/test/micro.jl
@@ -1,0 +1,6 @@
+using GLVisualize, Colors, FixedPointNumbers
+using Base.Test
+
+@test GLVisualize.Intensity{1,Float32}(Gray(N0f8(0.8))) == GLVisualize.Intensity{1,Float32}(Float32(N0f8(0.8)))
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+include("micro.jl")
+
 using GLVisualize
 include(GLVisualize.dir("examples", "ExampleRunner.jl"))
 using ExampleRunner


### PR DESCRIPTION
This is work motivated by the "volumes.jl" example in GLPlots. Now that VideoIO has migrated to the new Images, I don't really think there's any reason to keep the old one around, but I left it in place just in case. It's a slightly worse experience because of the lack of docstrings and incorrect line numbers (due to the use of `include_string`), but I think that's a good thing :smile:.

The most important step was to infer information about the nature of the image. One of the advantages of the new framework is that any `AbstractArray{T,3}` is genuinely 3-dimensional: you can no longer use a dimension to encode color. We could also dispatch separately on images-with-a-time-axis and any other kind of 3d image, but for now this uses branching due to limitations in SimpleTraits.
