### PR TITLE
Update build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-Build status (Linux x86-64):
-[![Build Status](https://ci.maleadt.net/buildbot/julia/png?builder=GLVisualize.jl:%20Julia%200.5%20(x86-64))](https://ci.maleadt.net/buildbot/julia/builders/GLVisualize.jl%3A%20Julia%200.5%20%28x86-64%29)
+**Build status**: [![](https://ci.maleadt.net/buildbot/julia/badge.svg?builder=GLVisualize.jl:%20Julia%200.5%20(x86-64)&badge=Julia%20v0.5)](https://ci.maleadt.net/buildbot/julia/builders/GLVisualize.jl%3A%20Julia%200.5%20%28x86-64%29)
 
-[![Coverage Status](https://coveralls.io/repos/github/JuliaGL/GLVisualize.jl/badge.svg?branch=HEAD)](https://coveralls.io/github/JuliaGL/GLVisualize.jl?branch=HEAD)
+**Code coverage**: [![Coverage Status](https://coveralls.io/repos/github/JuliaGL/GLVisualize.jl/badge.svg?branch=HEAD)](https://coveralls.io/github/JuliaGL/GLVisualize.jl?branch=HEAD)
 
 
 # GLVisualize


### PR DESCRIPTION
Also, where do you get your coverage info from? My bot currently doesn't do that for GLVisualize (only supports CodeCov).