### PR TITLE
Update deprecated syntax in color_chooser.jl. Addresses issue #213.

### DIFF
--- a/examples/gui/color_chooser.jl
+++ b/examples/gui/color_chooser.jl
@@ -29,7 +29,7 @@ _view(layout!(SimpleRectangle{Float32}(0,120,60,60), c_v), edit_screen, camera=:
 
 function multirandomwalk(n1, n2)
     a = rand(Point3f0, n1)*2f0
-    r = Array(Point3f0, n1*n2)
+    r = Array{Point3f0}(n1*n2)
     i = 1
     for j=1:n1
         pstart = a[j]


### PR DESCRIPTION
Simple change to update deprecated syntax for `Array`. Resolves issue #213. 